### PR TITLE
Rewrite elfeed-show-add-enclosure-to-playlist.

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -45,7 +45,7 @@ Called without arguments."
                  (function-item delete-window)
                  function))
 
-(defvar elfeed-show-playlist-buffer-name "elfeed-enclosures"
+(defvar elfeed-show-playlist-buffer-name " elfeed-enclosures"
   "Emms playlist buffer name for enclosures.")
 
 (defvar elfeed-show-refresh-function #'elfeed-show-refresh--mail-style


### PR DESCRIPTION
This accomplishes three things.
* elfeed-show-add-enclosure-to-playlist would fail because the current buffer wasn't an emms playlist.
* Enclosures are added to the buffer named in elfeed-show-playlist-buffer-name.
* Define 'info-title to be the title of the elfeed entry.