### PR TITLE
Respect `shr-max-image-proportion` when rendering elfeed-entry

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -214,9 +214,9 @@ The result depends on the value of `elfeed-show-unique-buffers'."
   (let ((buff (get-buffer-create (elfeed-show--buffer-name entry))))
     (with-current-buffer buff
       (elfeed-show-mode)
-      (setq elfeed-show-entry entry)
-      (elfeed-show-refresh))
-    (funcall elfeed-show-entry-switch buff)))
+      (setq elfeed-show-entry entry))
+    (funcall elfeed-show-entry-switch buff)
+    (elfeed-show-refresh)))
 
 (defun elfeed-show-next ()
   "Show the next item in the elfeed-search buffer."


### PR DESCRIPTION
I noticed that Elfeed would sometimes refuse to scale down images that were too large to be displayed in a given window; after some discussion on the [mailing list](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=71913), I realized this is because Elfeed renders *before* displaying a buffer, where it can't glean any information about window size (because there's no window).

Note that there is still an issue with SVG images not respecting `shr-max-image-proportion`, but that has been fixed in Emacs 30 thanks to @jimporter; that's not Elfeed's problem to fix.