### PR TITLE
Stop requiring other tests

### DIFF
--- a/tests/elfeed-curl-tests.el
+++ b/tests/elfeed-curl-tests.el
@@ -13,6 +13,4 @@
     (cl-loop for (type . url) in table
              do (should (eq (elfeed-curl--protocol-type url) type)))))
 
-(provide 'elfeed-curl-tests)
-
 ;;; elfeed-curl-tests.el ends here

--- a/tests/elfeed-db-tests.el
+++ b/tests/elfeed-db-tests.el
@@ -260,6 +260,4 @@
         (should (equal (tsort (elfeed-feed-entries feed-b-id))
                        (tsort feed-b-entries)))))))
 
-(provide 'elfeed-db-tests)
-
 ;;; elfeed-db-tests.el ends here

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -183,6 +183,4 @@
     (t "http://foo.example/a/b/" ".././c" "http://foo.example/a/c")
     (t "http://foo.example/a/b/" "../c/../../d" "http://foo.example/d")))
 
-(provide 'elfeed-lib-tests)
-
 ;;; elfeed-lib-tests.el ends here

--- a/tests/elfeed-search-tests.el
+++ b/tests/elfeed-search-tests.el
@@ -61,6 +61,4 @@
   (should (string-equal "@5-minutes-ago" (elfeed-search-unparse-filter '(:after 300))))
   (should (string-equal "@5-minutes-ago--1-minute-ago" (elfeed-search-unparse-filter '(:after 300 :before 60)))))
 
-(provide 'elfeed-search-tests)
-
 ;;; elfeed-search-tests.el ends here

--- a/tests/elfeed-tests.el
+++ b/tests/elfeed-tests.el
@@ -5,11 +5,6 @@
 (require 'ert)
 (require 'elfeed)
 (require 'elfeed-lib)
-(require 'xml-query-tests)
-(require 'elfeed-db-tests)
-(require 'elfeed-lib-tests)
-(require 'elfeed-search-tests)
-(require 'elfeed-curl-tests)
 
 (defvar elfeed-test-rss
   "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
@@ -466,7 +461,5 @@
              (entry (cl-first (elfeed-entries-from-atom "http://foo/" xml))))
         (should (equal (elfeed-entry-tags entry)
                        (elfeed-normalize-tags '(unread tag-a tag-b))))))))
-
-(provide 'elfeed-tests)
 
 ;;; elfeed-tests.el ends here

--- a/tests/xml-query-tests.el
+++ b/tests/xml-query-tests.el
@@ -22,6 +22,4 @@
     (should (equal (xml-query-all '(foo (baz bar) *) xml)
                    '("FOOBAZ" "FOO" "BAR")))))
 
-(provide 'xml-query-tests)
-
 ;;; xml-query-tests.el ends here


### PR DESCRIPTION
ERT since Emacs 29 disallows tests with the same name.  This can also happen when requiring other tests that have 'ert-deftest' and the required source is run before the requiring source, in which case the required source is run twice and all its 'ert-deftest' are considered reusing test names.  See also bug#66782[1].

This patch removes all requires on other test units, and remove all provides in test unit to prevent such error.  Currently this doesn't cause any issues.  In future, it would be better to put utility variable and functions in a separate helper unit to be able to require.

[1] https://debbugs.gnu.org/cgi/bugreport.cgi?bug=66782