### PR TITLE
Decode encoded strings in entry titles. Fixes skeeto/elfeed#484

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -443,7 +443,12 @@ The customization `elfeed-search-date-format' sets the formatting."
   (let* ((tags (elfeed-entry-tags entry))
          (date-float (elfeed-entry-date entry))
          (date-str (elfeed-search-format-date date-float))
-         (title (or (elfeed-meta--title entry) ""))
+         (title (elfeed-meta--title entry))
+         (title (or (and title
+                         (decode-coding-string title
+                                               (detect-coding-string title t)
+                                               t))
+                    ""))
          (title-faces (elfeed-search--faces tags))
          (feed (elfeed-entry-feed entry))
          (feed-title (and feed (elfeed-meta--title feed)))

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -467,6 +467,9 @@ The customization `elfeed-search-date-format' sets the formatting."
          (title (if (or (not title) (equal title ""))
                     (elfeed-entry-link entry)
                   title))
+         (title (and title
+                     (decode-coding-string
+                      title (detect-coding-string title t) t)))
          (title-faces (elfeed-search--faces (elfeed-entry-tags entry)))
          (window (get-buffer-window))
          (title-width (elfeed-clamp
@@ -484,7 +487,10 @@ The customization `elfeed-search-date-format' sets the formatting."
 (defun elfeed-search--column-feed (entry)
   "Format the feed column for ENTRY, return string."
   (when-let* ((feed (elfeed-entry-feed entry))
-              (title (elfeed-meta--title feed)))
+              (title (elfeed-meta--title feed))
+              (title (and title
+                          (decode-coding-string
+                           title (detect-coding-string title t) t))))
     (propertize title 'face 'elfeed-search-feed-face
                 'mouse-face 'highlight
                 'follow-link [elfeed-feed])))

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -374,14 +374,14 @@ Movement is configured by `elfeed-search-remain-on-entry'."
 (defun elfeed-search (&optional new-filter)
   "Enter `elfeed-search' buffer, optionally with a NEW-FILTER."
   (interactive)
-  (switch-to-buffer (elfeed-search-buffer))
-  (unless (eq major-mode 'elfeed-search-mode)
-    (elfeed-search-mode))
-  (when new-filter
-    ;; Scroll to top when resetting the buffer
-    (goto-char (point-min))
-    (set-window-start nil (point-min))
-    (elfeed-search-set-filter new-filter)))
+  (display-buffer (elfeed-search-buffer))
+  (with-current-buffer (elfeed-search-buffer)
+    (elfeed-search-mode)
+    (when new-filter
+      ;; Scroll to top when resetting the buffer
+      (goto-char (point-min))
+      (set-window-start nil (point-min))
+      (elfeed-search-set-filter new-filter))))
 
 (defun elfeed-search-buffer ()
   "Create and return search buffer."

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -208,6 +208,9 @@ Links are relative to BASE-URL if non-nil."
   "Update the buffer to match the selected entry, using a mail-style."
   (let* ((inhibit-read-only t)
          (title (elfeed-entry-title elfeed-show-entry))
+         (title (decode-coding-string title
+                                      (detect-coding-string title t)
+                                      t))
          (date (seconds-to-time (elfeed-entry-date elfeed-show-entry)))
          (authors (elfeed-meta elfeed-show-entry :authors))
          (link (elfeed-entry-link elfeed-show-entry))
@@ -276,12 +279,15 @@ The result depends on the value of `elfeed-show-unique-buffers'."
 
 (defun elfeed-show-entry (entry)
   "Display ENTRY in the current buffer."
-  (let ((buff (get-buffer-create (elfeed-show--buffer-name entry))))
-    (with-current-buffer buff
+  (let* ((buffer-title (elfeed-show--buffer-name entry))
+         (buffer (get-buffer-create (decode-coding-string buffer-title
+                                      (detect-coding-string buffer-title t)
+                                      t))))
+    (with-current-buffer buffer
       (elfeed-show-mode)
       (setq elfeed-show-entry entry)
       (elfeed-show-refresh))
-    (funcall elfeed-show-entry-switch buff)))
+    (funcall elfeed-show-entry-switch buffer)))
 
 (defun elfeed-show-next (&optional n)
   "Show the Nth next item in the `elfeed-search' buffer."
@@ -555,9 +561,12 @@ Prompts for ENCLOSURE-INDEX when called interactively."
 
 (defun elfeed-show-bookmark-make-record ()
   "Save the current position and the entry into a bookmark."
-  (let ((id (elfeed-entry-id elfeed-show-entry))
+  (let* ((id (elfeed-entry-id elfeed-show-entry))
         (position (point))
-        (title (elfeed-entry-title elfeed-show-entry)))
+        (title (elfeed-entry-title elfeed-show-entry))
+        (title (decode-coding-string title
+                                      (detect-coding-string title t)
+                                      t)))
     `(,(format "elfeed entry \"%s\"" title)
       (id . ,id)
       (location . ,title)

--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -193,6 +193,8 @@ All attachments are saved in the chosen directory."
   "Update the buffer to match the selected entry, using a mail-style."
   (let* ((inhibit-read-only t)
          (title (elfeed-entry-title elfeed-show-entry))
+         (title (decode-coding-string
+                 title (detect-coding-string title t) t))
          (date (seconds-to-time (elfeed-entry-date elfeed-show-entry)))
          (authors (elfeed-meta elfeed-show-entry :authors))
          (link (elfeed-entry-link elfeed-show-entry))
@@ -259,7 +261,12 @@ The result depends on the value of `elfeed-show-unique-buffers'."
 
 (defun elfeed-show-entry (entry)
   "Display ENTRY in the current buffer."
-  (let ((buffer (get-buffer-create (elfeed-show--buffer-name entry))))
+  (let* ((buffer-title (elfeed-show--buffer-name entry))
+         (buffer-title (decode-coding-string
+                        buffer-title
+                        (detect-coding-string buffer-title t)
+                        t))
+         ((buffer (get-buffer-create buffer-title))))
     (with-current-buffer buffer
       (elfeed-show-mode)
       (setq elfeed-show-entry entry))
@@ -673,7 +680,10 @@ content is stored in the entry metadata under the key :link-content."
 
 (defun elfeed-show-bookmark-make-record ()
   "Save the current position and the entry into a bookmark."
-  (let ((title (elfeed-meta--title elfeed-show-entry)))
+  (let* ((title (elfeed-meta--title elfeed-show-entry))
+         (title (decode-coding-string
+                 title
+                 (detect-coding-string title t) t)))
     `(,(format "elfeed entry \"%s\"" title)
       (id . ,(elfeed-entry-id elfeed-show-entry))
       (location . ,title)

--- a/elfeed-tree.el
+++ b/elfeed-tree.el
@@ -168,9 +168,9 @@
 (defun elfeed-tree ()
   "Enter `elfeed-tree' buffer."
   (interactive)
-  (switch-to-buffer (elfeed-tree--buffer))
-  (unless (eq major-mode 'elfeed-tree-mode)
-    (elfeed-tree-mode)))
+  (display-buffer (elfeed-tree--buffer))
+  (with-current-buffer (elfeed-tree--buffer))
+    (elfeed-tree-mode))
 
 (defun elfeed-tree--buffer ()
   "Create and return tree buffer."

--- a/elfeed.el
+++ b/elfeed.el
@@ -837,15 +837,18 @@ if another update is already running."
 ;; New entry filtering
 
 (cl-defun elfeed-make-tagger
-    (&key feed-title feed-url entry-title entry-link categories
+    (&key feed-title feed-url feed-author entry-title entry-link categories
+          entry-content-type entry-enclosure
           after before add remove callback)
   "Create a function that adds or removes tags on matching entries.
 
-FEED-TITLE, FEED-URL, ENTRY-TITLE, ENTRY-LINK and CATEGORIES are regular
-expressions or an expression (not <regex>), which indicates a negative
-match.  AFTER and BEFORE are relative times (see `elfeed-time-duration').
-Entries must match all provided expressions.  If an entry matches, add
-tags ADD and remove tags REMOVE.  Call CALLBACK for each entry.
+FEED-TITLE, FEED-URL, FEED-AUTHOR, ENTRY-TITLE, CATEGORIES, ENTRY-LINK,
+ENTRY-ENCLOSURE and ENTRY-CONTENT-TYPE
+are regular expressions or a list \(not <regex>\),
+which indicates a negative match.  AFTER and BEFORE are relative times
+\(see `elfeed-time-duration'\).  Entries must match all provided
+expressions.  If an entry matches, add tags ADD and remove tags
+REMOVE.  Call CALLBACK for each entry.
 
 Examples,
 
@@ -878,9 +881,12 @@ The returned function should be added to `elfeed-new-entry-hook'."
           (when (and
                  (match feed-title  (elfeed-feed-title  feed))
                  (match feed-url    (elfeed-feed-url    feed))
+                 (match feed-author (elfeed-feed-author feed))
                  (match entry-title (elfeed-entry-title entry))
                  (match entry-link  (elfeed-entry-link  entry))
                  (match categories  (elfeed-meta entry :categories))
+                 (match entry-content-type (elfeed-entry-content-type entry))
+                 (match entry-enclosure (elfeed-entry-enclosures entry))
                  (or (not after-time)  (> date (- (float-time) after-time)))
                  (or (not before-time) (< date (- (float-time) before-time))))
             (when add


### PR DESCRIPTION
Includes #531 and #540.

Feel free to merge in any order.