### PR TITLE
Improve spacing alignment in elfeed-search buffer

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -451,13 +451,16 @@ The customization `elfeed-search-date-format' sets the formatting."
     (insert (elfeed-add-properties date-str
                                    'face 'elfeed-search-date-face
                                    'mouse-face 'highlight 'elfeed-date date-float)
-            " "
+            (propertize " " 'display `(space :align-to ,(1+ (string-width date-str))))
             (elfeed-add-properties title-column
                                    'face title-faces 'kbd-help title
                                    'mouse-face 'highlight 'elfeed-entry-title t))
     (when feed-title
-      (insert " " (propertize feed-title 'face 'elfeed-search-feed-face
-                              'mouse-face 'highlight 'elfeed-feed feed)))
+      (insert (propertize " " 'display `(space :align-to ,(+ (string-width date-str)
+                                                             (string-width title-column)
+                                                             2)))
+              (propertize feed-title 'face 'elfeed-search-feed-face
+			  'mouse-face 'highlight 'elfeed-feed feed)))
     (when tags
       (insert " (" (elfeed-search--format-tags tags) ")"))))
 

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -552,20 +552,23 @@ never show a relative time."
                                elfeed-search-title-min-width
                                title-width
                                elfeed-search-title-max-width)
-                        :left)))
+                        :left))
+	 (date-width (string-width date))
+	 (title-column-width (string-width title-column)))
     (insert (elfeed-add-properties date
                                    'face 'elfeed-search-date-face
                                    'mouse-face 'highlight
                                    'follow-link [elfeed-date])
-            " "
+            (propertize " " 'display `(space :align-to ,(1+ date-width)))
             (elfeed-add-properties title-column
                                    'face title-faces 'kbd-help title
                                    'mouse-face 'highlight
                                    'follow-link [elfeed-entry]))
     (when feed-title
-      (insert " " (propertize feed-title 'face 'elfeed-search-feed-face
-                              'mouse-face 'highlight
-                              'follow-link [elfeed-feed])))
+      (insert (propertize " " 'display `(space :align-to ,(+ 2 date-width title-column-width)))
+	      (propertize feed-title 'face 'elfeed-search-feed-face
+                          'mouse-face 'highlight
+                          'follow-link [elfeed-feed])))
     (when tags
       (insert " (" (elfeed-search--format-tags tags) ")"))))
 


### PR DESCRIPTION
Use display property with :align-to to ensure consistent spacing between date and title columns, preventing misalignment issues with variable-width content.


Before the patch: 

<img width="1884" height="2067" alt="Screenshot from 2026-05-09 00-20-58" src="https://github.com/user-attachments/assets/6afc3fa0-c0a4-4e9f-a732-1c2553b97d42" />


After the patch:

<img width="1884" height="2067" alt="Screenshot from 2026-05-09 00-20-27" src="https://github.com/user-attachments/assets/5fc7758d-fe2a-4f8d-94f6-9f89aa207bb7" />
