### PR TITLE
elfeed-db-gc: Scan entry and feed meta data for elfeed-refs

### DIFF
--- a/elfeed-db.el
+++ b/elfeed-db.el
@@ -408,7 +408,12 @@ Runs `elfeed-db-unload-hook' after unloading the database."
 
 (defun elfeed-meta (thing key &optional default)
   "Access metadata for THING (entry, feed) under KEY.
-Return DEFAULT if unavailable."
+Return DEFAULT if unavailable.  During `elfeed-db-gc' and
+`elfeed-db-pack', metadata values will be scanned for `elfeed-ref'
+objects, such that references in metadata will be kept alive.  Note that
+only list data structures will be scanned (e.g., cons, list, alist,
+plist).  The data structures must not be cyclic since this is not
+supported by the database format."
   (or (plist-get (elfeed-meta--plist thing) key)
       default))
 
@@ -536,20 +541,42 @@ Return DEFAULT if unavailable."
                  (remhash id elfeed-db-feeds)))
              elfeed-db-feeds)))
 
+(defun elfeed-db--scan-1 (cb obj)
+  "Scan OBJ for `elfeed-ref' references and call CB for each reference."
+  ;; Written out as a loop to scan lists efficiently since Elisp lacks TCO.
+  ;; Note that cyclic objects are not supported by the database format.
+  (while (cond
+          ((elfeed-ref-p obj)
+           (funcall cb obj)
+           nil)
+          ((consp obj)
+           (elfeed-db--scan-1 cb (car obj))
+           (setf obj (cdr obj))))))
+
+(defun elfeed-db--scan (cb)
+  "Scan database for `elfeed-ref' references and call CB for each reference."
+  (let ((feeds (make-hash-table :test #'equal)))
+    (elfeed-db-visit (entry)
+      ;; Search for references in content, entry metadata and feed metadata
+      (elfeed-db--scan-1 cb (elfeed-entry-content entry))
+      (elfeed-db--scan-1 cb (elfeed-entry-meta entry))
+      ;; Only scan feed metadata once. Keep track of feeds in feeds.
+      (unless (gethash (elfeed-entry-feed-id entry) feeds)
+        (setf (gethash (elfeed-entry-feed-id entry) feeds) t)
+        (elfeed-db--scan-1 cb (elfeed-feed-meta (elfeed-entry-feed entry)))))))
+
 (defun elfeed-db-gc (&optional stats-p)
   "Clean up unused content from the content database.
 If STATS-P is true, return the space cleared in bytes."
   (elfeed-db-gc-empty-feeds)
   (let* ((data (expand-file-name "data" elfeed-db-directory))
          (dirs (directory-files data t "\\`[0-9a-z]\\{2\\}\\'"))
-         (ids (cl-mapcan (lambda (d) (directory-files d nil nil t)) dirs))
-         (table (make-hash-table :test 'equal)))
+         (ids (mapcan (lambda (d) (directory-files d nil nil t)) dirs))
+         (table (make-hash-table :test #'equal)))
     (dolist (id ids)
       (setf (gethash id table) nil))
-    (elfeed-db-visit (entry)
-      (let ((content (elfeed-entry-content entry)))
-        (when (elfeed-ref-p content)
-          (setf (gethash (elfeed-ref-id content) table) t))))
+    (elfeed-db--scan
+     (lambda (ref) (setf (gethash (elfeed-ref-id ref) table) t)))
     (cl-loop for id hash-keys of table using (hash-value used)
              for used-p = (or used (member id '("." "..")))
              when (and (not used-p) stats-p)
@@ -568,21 +595,21 @@ If STATS-P is true, return the space cleared in bytes."
          (content-temp (file-name-with-extension content-dest ".tmp.gz"))
          (index-dest (elfeed-ref-archive-filename ".index"))
          (index-temp (file-name-with-extension index-dest ".tmp.index"))
-         (next-archive (make-hash-table :test 'equal))
+         (next-archive (make-hash-table :test #'equal))
          (coding-system-for-write 'utf-8)
          (write-region-inhibit-fsync nil)
          (packed ()))
     (make-directory (expand-file-name "data" elfeed-db-directory) t)
     (with-temp-file content-temp
-      (elfeed-db-visit (entry)
-        (let ((ref (elfeed-entry-content entry))
-              (start (1- (point))))
-          (when (elfeed-ref-p ref)
-            (when-let* ((content (elfeed-deref ref)))
-              (push ref packed)
-              (insert content)
-              (setf (gethash (elfeed-ref-id ref) next-archive)
-                    (cons start (1- (point)))))))))
+      (elfeed-db--scan
+       (lambda (ref)
+         (when-let* (((not (gethash (elfeed-ref-id ref) next-archive)))
+                     (content (elfeed-deref ref)))
+           (push ref packed)
+           (let ((start (1- (point))))
+             (insert content)
+             (setf (gethash (elfeed-ref-id ref) next-archive)
+                   (cons start (1- (point)))))))))
     (with-temp-file index-temp
       (let ((standard-output (current-buffer))
             (print-level nil)

--- a/tests/elfeed-db-tests.el
+++ b/tests/elfeed-db-tests.el
@@ -246,6 +246,77 @@
                    (content (elfeed-deref (elfeed-entry-content entry))))
                (should (string= title content))))))))))
 
+(ert-deftest elfeed-ref-pack-metadata ()
+  (catch 'test-abort
+    (with-elfeed-test
+     (let* ((jka-compr-verbose nil)
+            (feed (elfeed-test-generate-feed))
+            (entry (elfeed-test-generate-entry feed))
+            ;; Keep these refs reachable only through metadata.
+            (content-ref (elfeed-ref "entry content"))
+            (entry-ref (elfeed-ref "entry metadata content"))
+            (feed-ref (elfeed-ref "feed metadata content"))
+            (check
+             (lambda ()
+               (let (found)
+                 (elfeed-db--scan
+                  (lambda (ref) (push (elfeed-ref-id ref) found)))
+                 (should (equal (delete-consecutive-dups (sort found #'string<))
+                                (sort (list (elfeed-ref-id content-ref)
+                                            (elfeed-ref-id entry-ref)
+                                            (elfeed-ref-id feed-ref)) #'string<)))
+                 (should (equal "entry content"
+                                (elfeed-deref (elfeed-entry-content entry))))
+                 (should (equal "entry metadata content"
+                                (elfeed-deref
+                                 (cdr (assq 'test-ref (elfeed-meta entry :saved))))))
+                 (should (equal "feed metadata content"
+                                (elfeed-deref
+                                 (cdr (assq 'test-ref (elfeed-meta feed :saved))))))))))
+       (unless (elfeed-gzip-supported-p)
+         (message "warning: gzip auto-compression unsupported, skipping")
+         (throw 'test-abort nil))
+       (elfeed-db-add (list entry))
+       (setf (elfeed-entry-content entry) content-ref)
+       ;; Use cons-based metadata so this exercises the supported scan model.
+       (setf (elfeed-meta entry :saved) `((test-ref . ,entry-ref))
+             (elfeed-meta feed  :saved) `((test-ref . ,feed-ref)))
+
+       (funcall check)
+       (elfeed-db-unload)
+
+       (elfeed-db-ensure)
+       (elfeed-db-pack)
+       (funcall check)
+       (elfeed-db-unload)
+
+       (elfeed-db-ensure)
+       (elfeed-db-gc)
+       (funcall check)))))
+
+(ert-deftest elfeed-db-scan ()
+  (with-elfeed-test
+   (let* ((x (elfeed-ref "x"))
+          (y (elfeed-ref "y"))
+          (test-list (list x 1 "foo" y :bar))
+          (test-alist `((a . 0) (b . ,x) (c . ,y) (d . 1)))
+          (test-dotted `(,x 1 "foo" . ,y))
+          (test-nested (list test-list test-alist test-dotted))
+          (refs ())
+          (cb (lambda (ref) (push (elfeed-ref-id ref) refs))))
+     (setq refs ())
+     (elfeed-db--scan-1 cb nil)
+     (elfeed-db--scan-1 cb "str")
+     (elfeed-db--scan-1 cb ["vec"])
+     (elfeed-db--scan-1 cb x)
+     (should (equal refs (list (elfeed-ref-id x))))
+     (dolist (test-obj (list test-list test-alist
+                             test-dotted test-nested))
+       (setq refs ())
+       (elfeed-db--scan-1 cb test-obj)
+       (should (equal (delete-consecutive-dups (sort refs #'string<))
+                      (sort (list (elfeed-ref-id x) (elfeed-ref-id y)) #'string<)))))))
+
 (ert-deftest elfeed-db-meta ()
   (with-elfeed-test
    (let* ((feed (elfeed-db-get-feed (elfeed-test-generate-url)))


### PR DESCRIPTION
Lists are scanned recursively. Other objects are not scanned.

Fixes #376 and #457