### PR TITLE
Improve elfeed search hook handling

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -46,6 +46,11 @@
 The functions may modify the search buffer or add overlays, for example
 `elfeed-search-add-separators'.")
 
+(defcustom elfeed-search-separators t
+  "Add separators to Elfeed entries according to their date."
+  :group 'elfeed
+  :type 'boolean)
+
 (defcustom elfeed-search-update-delay 0.2
   "Delay search buffer updates to avoid redundant redraws.
 The delay is in seconds."
@@ -297,7 +302,9 @@ Movement is configured by `elfeed-search-remain-on-entry'."
   (add-hook 'elfeed-update-hook #'elfeed-search--update-debounce)
   (add-hook 'elfeed-update-init-hook #'elfeed-search--update-force)
   (add-hook 'window-size-change-functions #'elfeed-search--resize nil 'local)
-  (add-hook 'elfeed-search-update-hook #'elfeed-search-add-separators))
+
+  (when elfeed-search-separators
+    (add-hook 'elfeed-search-update-hook #'elfeed-search-add-separators)))
 
 (defun elfeed-search--header ()
   "Computes the string to be used as the Elfeed header."

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -41,7 +41,7 @@
 (defvar elfeed-search-last-update 0
   "The last time the buffer was redrawn in epoch seconds.")
 
-(defvar elfeed-search-update-hook (list #'elfeed-search-add-separators)
+(defvar elfeed-search-update-hook ()
   "List of functions to run immediately following a search buffer update.
 The functions may modify the search buffer or add overlays, for example
 `elfeed-search-add-separators'.")
@@ -291,6 +291,14 @@ Movement is configured by `elfeed-search-remain-on-entry'."
                      elfeed-log-error-count))
             " ")))
 
+(defun elfeed-search--hooks-setup ()
+  "Set up the necessary hooks for `elfeed-search-mode'."
+  (add-hook 'minibuffer-setup-hook 'elfeed-search--minibuffer-setup)
+  (add-hook 'elfeed-update-hook #'elfeed-search--update-debounce)
+  (add-hook 'elfeed-update-init-hook #'elfeed-search--update-force)
+  (add-hook 'window-size-change-functions #'elfeed-search--resize nil 'local)
+  (add-hook 'elfeed-search-update-hook #'elfeed-search-add-separators))
+
 (defun elfeed-search--header ()
   "Computes the string to be used as the Elfeed header."
   (cond
@@ -364,9 +372,7 @@ Movement is configured by `elfeed-search-remain-on-entry'."
               hl-line-sticky-flag t)
   (buffer-disable-undo)
   (hl-line-mode)
-  (add-hook 'elfeed-update-hook #'elfeed-search--update-debounce)
-  (add-hook 'elfeed-update-init-hook #'elfeed-search--update-force)
-  (add-hook 'window-size-change-functions #'elfeed-search--resize nil 'local)
+  (elfeed-search--hooks-setup)
   (elfeed-db--save-on-quit)
   (elfeed-search-update :force))
 
@@ -1357,8 +1363,6 @@ Sets the :title key of the feed's metadata.  See `elfeed-meta'."
     (set-syntax-table elfeed-search-filter-syntax-table)
     (when (eq :live elfeed-search-filter-active)
       (add-hook 'post-command-hook 'elfeed-search--live-update nil :local))))
-
-(add-hook 'minibuffer-setup-hook 'elfeed-search--minibuffer-setup)
 
 (defun elfeed-search--live-update ()
   "Update the `elfeed-search' buffer based on the contents of the minibuffer."


### PR DESCRIPTION
Hello again.

This pull request contains two commits. 

The first one is just an opinionated refactor to the already existing code. In practice this doesn't actually modify the functionality of Elfeed, but rather it groups (almost) all the used hooks into one function. This should make it easier to manage hooks.

The second commit adds a custom variable to manage separators and, probably more important, it makes it easier to add and remove values on elfeed-search-update-hook in the future. From what I have noticed when using Emacs, hooks are more of a dynamic mechanism, and asking the user to directly interface with them may or may not cause unforeseen effects.

Feel free to accept one, two, or neither commits.