### PR TITLE
Add elfeed-show-entry-date-format option

### DIFF
--- a/elfeed-show.el
+++ b/elfeed-show.el
@@ -71,6 +71,11 @@ Called without arguments."
   :group 'elfeed
   :type '(choice function))
 
+(defcustom elfeed-show-entry-date-format "%a, %e %b %Y %T %Z"
+  "The ‘format-time-string’ format for date in the elfeed-entry buffer."
+  :group 'elfeed
+  :type 'string)
+
 (defvar elfeed-show-refresh-function #'elfeed-show-refresh--mail-style
   "Function called to refresh the `*elfeed-entry*' buffer.")
 
@@ -171,7 +176,7 @@ Called without arguments."
          (link (elfeed-entry-link elfeed-show-entry))
          (tags (elfeed-entry-tags elfeed-show-entry))
          (tagsstr (mapconcat #'symbol-name tags ", "))
-         (nicedate (format-time-string "%a, %e %b %Y %T %Z" date))
+         (nicedate (format-time-string elfeed-show-entry-date-format date))
          (content (elfeed-deref (elfeed-entry-content elfeed-show-entry)))
          (type (elfeed-entry-content-type elfeed-show-entry))
          (feed (elfeed-entry-feed elfeed-show-entry))


### PR DESCRIPTION
This commit is simple: it adds a variable that allows users to customize the date shown in the elfeed-entry buffer.