### PR TITLE
Split elfeed-search-print-entry--default

### DIFF
--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -524,11 +524,14 @@ never show a relative time."
 
 (defun elfeed-search-format-column--date (entry)
   "Format the date information for ENTRY."
-  (let ((date (elfeed-search-format-date (elfeed-entry-date entry))))
-    (elfeed-add-properties date
-                           'face 'elfeed-search-date-face
-                           'mouse-face 'highlight
-                           'follow-link [elfeed-date])))
+  (let ((date (elfeed-search-format-date (elfeed-entry-date entry)))
+        (date-width (cadr elfeed-search-date-format)))
+    (cons
+     (elfeed-add-properties date
+                            'face 'elfeed-search-date-face
+                            'mouse-face 'highlight
+                            'follow-link [elfeed-date])
+     date-width)))
 
 (defun elfeed-search-format-column--title (entry)
   "Format the title information for ENTRY."
@@ -545,10 +548,12 @@ never show a relative time."
                           10 elfeed-search-trailing-width)
                        elfeed-search-title-max-width))
          (title-column (elfeed-format-column title title-width :left)))
-    (elfeed-add-properties title-column
-                           'face title-faces 'kbd-help title
-                           'mouse-face 'highlight
-                           'follow-link [elfeed-entry])))
+    (cons
+     (elfeed-add-properties title-column
+                            'face title-faces 'kbd-help title
+                            'mouse-face 'highlight
+                            'follow-link [elfeed-entry])
+     title-width)))
 
 (defun elfeed-search-format-column--feed (entry)
   "Format the feed information for ENTRY."
@@ -565,14 +570,24 @@ never show a relative time."
 
 (defun elfeed-search-print-entry--default (entry)
   "Print ENTRY to the buffer."
-  (let ((date (elfeed-search-format-column--date entry))
-        (title (elfeed-search-format-column--title entry))
-        (feed (elfeed-search-format-column--feed entry))
-        (tags (elfeed-search-format-column--tags entry)))
+  (let* ((date (elfeed-search-format-column--date entry))
+         (date-str (car date))
+         (date-width (cdr date))
+         (title (elfeed-search-format-column--title entry))
+         (title-str (car title))
+         (title-width (cdr title))
+         (feed (elfeed-search-format-column--feed entry))
+         (tags (elfeed-search-format-column--tags entry)))
     (insert
      (concat
-      date " " title
-      (when feed (concat " " feed))
+      date-str
+      (propertize " " 'display `(space :align-to ,(1+ date-width)))
+      title-str
+      (when feed
+        (concat
+         (propertize " " 'display `( space :align-to
+                                     ,(+ 2 date-width title-width)))
+         feed))
       (when tags (concat " " tags))))))
 
 (defun elfeed-search-parse-filter (filter)

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -522,42 +522,58 @@ never show a relative time."
                  'follow-link [elfeed-tag]))
    tags ","))
 
-(defun elfeed-search-print-entry--default (entry)
-  "Print ENTRY to the buffer."
+(defun elfeed-search-format-column--date (entry)
+  "Format the date information for ENTRY."
+  (let ((date (elfeed-search-format-date (elfeed-entry-date entry))))
+    (elfeed-add-properties date
+                           'face 'elfeed-search-date-face
+                           'mouse-face 'highlight
+                           'follow-link [elfeed-date])))
+
+(defun elfeed-search-format-column--title (entry)
+  "Format the title information for ENTRY."
   (let* ((tags (elfeed-entry-tags entry))
-         (date (elfeed-search-format-date (elfeed-entry-date entry)))
          (title (elfeed-meta--title entry))
          (title (if (or (not title) (equal title ""))
                     (elfeed-entry-link entry)
                   title))
          (title-faces (elfeed-search--faces tags))
-         (feed (elfeed-entry-feed entry))
-         (feed-title (and feed (elfeed-meta--title feed)))
          (window (get-buffer-window))
          (title-width (elfeed-clamp
                        elfeed-search-title-min-width
                        (- (if window (window-width window) (frame-width))
-                         10 elfeed-search-trailing-width)
+                          10 elfeed-search-trailing-width)
                        elfeed-search-title-max-width))
-         (title-column (elfeed-format-column title title-width :left))
-         (date-width (cadr elfeed-search-date-format)))
-    (insert (elfeed-add-properties date
-                                   'face 'elfeed-search-date-face
-                                   'mouse-face 'highlight
-                                   'follow-link [elfeed-date])
-            (propertize " " 'display `(space :align-to ,(1+ date-width)))
-            (elfeed-add-properties title-column
-                                   'face title-faces
-                                   'mouse-face 'highlight
-                                   'follow-link [elfeed-entry]))
-    (when feed-title
-      (insert (propertize " " 'display `( space :align-to
-                                          ,(+ 2 date-width title-width)))
-              (propertize feed-title 'face 'elfeed-search-feed-face
-                          'mouse-face 'highlight
-                          'follow-link [elfeed-feed])))
-    (when tags
-      (insert " (" (elfeed-search--format-tags tags) ")"))))
+         (title-column (elfeed-format-column title title-width :left)))
+    (elfeed-add-properties title-column
+                           'face title-faces 'kbd-help title
+                           'mouse-face 'highlight
+                           'follow-link [elfeed-entry])))
+
+(defun elfeed-search-format-column--feed (entry)
+  "Format the feed information for ENTRY."
+  (if-let* ((feed (elfeed-entry-feed entry))
+            (feed-title (and feed (elfeed-meta--title feed))))
+      (propertize feed-title 'face 'elfeed-search-feed-face
+                  'mouse-face 'highlight
+                  'follow-link [elfeed-feed])))
+
+(defun elfeed-search-format-column--tags (entry)
+  "Format the tags information for ENTRY."
+  (if-let ((tags (elfeed-entry-tags entry)))
+      (concat "(" (elfeed-search--format-tags tags) ")")))
+
+(defun elfeed-search-print-entry--default (entry)
+  "Print ENTRY to the buffer."
+  (let ((date (elfeed-search-format-column--date entry))
+        (title (elfeed-search-format-column--title entry))
+        (feed (elfeed-search-format-column--feed entry))
+        (tags (elfeed-search-format-column--tags entry)))
+    (insert
+     (concat
+      date " " title
+      (when feed (concat " " feed))
+      (when tags (concat " " tags))))))
 
 (defun elfeed-search-parse-filter (filter)
   "Parse the elements of a search FILTER into a plist."


### PR DESCRIPTION
The display of the search buffer is customizable with the variable `elfeed-search-print-entry-function`, but `elfeed-search-print-entry--default` is a monolithic function that inserts everything at once. That makes it difficult to insert custom columns or modify the appearance of a single column without having to copy-paste the whole function.

The columns are almost completely independent, so `elfeed-search-print-entry--default` can be split cleanly. This pull request splits it into one function per column, and `elfeed-search-print-entry--default` simply concatenates and insert the propertized strings. 

The only difference with the original function is that I removed the `:align-to` property from the spaces after the date and the entry title. They are already formatted to have a fixed width, so the property doesn't seem needed, and aligning to a fixed position in the buffer doesn't work well if custom columns are added.