### PR TITLE
elfeed--header-button: Attach keymap as text property

### DIFF
--- a/elfeed.el
+++ b/elfeed.el
@@ -930,12 +930,25 @@ saved to your customization file."
                        (cdr str) 'elfeed-header-button (car str))))
     (call-interactively button)))
 
+(defvar elfeed--header-button-keymap
+  (let ((map (make-sparse-keymap)))
+    ;; Attach the click handler directly to the button text so it wins
+    ;; over the global `<header-line> <mouse-1>' binding regardless of
+    ;; the buffer's major/minor-mode maps.  Bind `down-mouse-1' to
+    ;; `ignore' so `mouse-drag-header-line' does not consume the press
+    ;; before `mouse-1' fires.
+    (define-key map [header-line down-mouse-1] #'ignore)
+    (define-key map [header-line mouse-1] #'elfeed-header-button)
+    map)
+  "Keymap attached as a text property to header line buttons.")
+
 (defun elfeed--header-button (command &optional text help)
   "Create header line button for COMMAND with optional TEXT and HELP."
   (propertize (or text (symbol-name command))
               'elfeed-header-button command
               'help-echo (or help (format "Run `%s'" command))
-              'mouse-face 'highlight))
+              'mouse-face 'highlight
+              'keymap elfeed--header-button-keymap))
 
 (defun elfeed--header-log-button ()
   "Button to show the Elfeed log."


### PR DESCRIPTION
## Problem

The header-line buttons in `elfeed-search` (the `Updated …` link and each filter word) rely on the major-mode keymap binding

```elisp
"<header-line> <mouse-1>" #'elfeed-header-button
```

in `elfeed-search-mode-map` (`elfeed-search.el:219`) to fire `elfeed-header-button`. In practice this is fragile:

- The global `<header-line> <down-mouse-1>` → `mouse-drag-header-line` binding can consume the button press before `<mouse-1>` is delivered, depending on Emacs version and frame setup.
- Any minor mode that shadows `<header-line> <mouse-1>` via `emulation-mode-map-alists` silently breaks the buttons.

Symptom in the field: hovering a filter word shows the `"Remove filter X"` tooltip (so the property and help text are there), but clicking it does nothing — `view-lossage` shows `mouse-select-window` firing instead of `elfeed-header-button`, even when `(key-binding [header-line mouse-1])` correctly returns `elfeed-header-button` in the same buffer.

## Fix

Attach the click handler directly to the button text via a `keymap` text property. Text-property keymaps have higher precedence than both the buffer's mode-map *and* any minor-mode/global map in Emacs's key lookup, so the button works regardless of the surrounding keymap stack.

Also bind `<header-line> <down-mouse-1>` to `ignore` in the same map so `mouse-drag-header-line` does not eat the press before `<mouse-1>` fires.

This is a strict superset of the prior behavior: environments where the mode-map binding already worked continue to work, and the cases that were silently broken now work too. The pre-existing `<header-line> <mouse-1>` binding in `elfeed-search-mode-map` is retained as a fallback.

## Verification

Batch test confirms the property is attached and the keymap resolves correctly:

```
button: "+unread"
keymap on text: t
  header-line mouse-1     -> elfeed-header-button
  header-line down-mouse-1 -> ignore
help-echo: "Remove filter +unread"
elfeed-header-button prop: #[nil ((message "toggled")) (t) nil nil nil]
```

Manually verified in a live Emacs that was previously not invoking the click handler — filter words are now clickable and remove the corresponding filter.