### PR TITLE
Replace obsolete functions with cl version

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -389,7 +389,7 @@ URL is the requested resource."
         (unwind-protect
             (funcall cb result)
           ;; Always clean up
-          (when (zerop (decf elfeed-curl--refcount))
+          (when (zerop (cl-decf elfeed-curl--refcount))
             (kill-buffer)))))))
 
 (defun elfeed-curl--fail-callback (buffer cb)
@@ -398,7 +398,7 @@ The callback is run within BUFFER."
   (with-current-buffer buffer
     (unwind-protect
         (funcall cb nil)
-      (when (zerop (decf elfeed-curl--refcount))
+      (when (zerop (cl-decf elfeed-curl--refcount))
         (kill-buffer)))))
 
 (defun elfeed-curl--sentinel (process status)
@@ -504,7 +504,7 @@ curl invocation."
 (defun elfeed-curl--queue-wrap (cb)
   "Wrap the curl CB so that it operates the queue."
   (lambda (status)
-    (decf elfeed-curl-queue-active)
+    (cl-decf elfeed-curl-queue-active)
     (elfeed-curl--run-queue)
     (funcall cb status)))
 
@@ -522,7 +522,7 @@ curl invocation."
               elfeed-curl-queue)
     (cl-destructuring-bind (url cb headers method data) (pop elfeed-curl-queue)
       (elfeed-log 'debug "retrieve %s" url)
-      (incf elfeed-curl-queue-active 1)
+      (cl-incf elfeed-curl-queue-active 1)
       (elfeed-curl-retrieve
        url
        (if (functionp cb)

--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -429,7 +429,7 @@ Links are relative to BASE-URL if non-nil."
         ;; HACK: Ensure that inserted images are not outdated, if the buffer content
         ;; has changed in the meantime.  There should be a better solution in Emacs.
         ;; See Emacs bug#80945 and https://github.com/emacs-elfeed/elfeed/issues/550.
-        (cl-letf* ((tick (incf elfeed--image-hack-tick))
+        (cl-letf* ((tick (cl-incf elfeed--image-hack-tick))
                    (orig (symbol-function 'url-queue-retrieve))
                    ((symbol-function 'url-queue-retrieve)
                     (lambda (url cb &rest args)

--- a/elfeed-log.el
+++ b/elfeed-log.el
@@ -82,7 +82,7 @@ FMT must be a string suitable for `format' given OBJECTS as arguments."
                           (error 'elfeed-log-error-level-face)))
         (inhibit-read-only t))
     (when (eq level 'error)
-      (incf elfeed-log-error-count))
+      (cl-incf elfeed-log-error-count))
     (when (>= (elfeed-log--level-number level)
               (elfeed-log--level-number elfeed-log-level))
       (with-current-buffer log-buffer

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -1399,7 +1399,7 @@ The update is delayed by `elfeed-search-live-delay'."
         (when-let* ((entry (get-text-property (point) 'elfeed-entry))
                     (title (elfeed-search--separator-title entry))
                     ((not (equal title last))))
-          (incf count)
+          (cl-incf count)
           (setq ov (make-overlay (pos-bol) (pos-bol)))
           (overlay-put ov 'category 'elfeed-search-separator)
           (overlay-put ov 'before-string

--- a/elfeed-tree.el
+++ b/elfeed-tree.el
@@ -234,16 +234,16 @@ format (tag unread read)."
           (unless (hash-table-contains-p tag tags-ht)
             (puthash tag (list tag 0 0) tags-ht))
           (if unread
-              (incf (cadr (gethash tag tags-ht)))
-            (incf (caddr (gethash tag tags-ht)))))
+              (cl-incf (cadr (gethash tag tags-ht)))
+            (cl-incf (caddr (gethash tag tags-ht)))))
         ;; Collect feeds in feeds hash table.
         (unless (hash-table-contains-p feed-id feeds-ht)
           (puthash feed-id (list (elfeed-meta--title feed) 0 0 feed
                                  (elfeed-feed-autotags feed))
                    feeds-ht))
         (if unread
-            (incf (cadr (gethash feed-id feeds-ht)))
-          (incf (caddr (gethash feed-id feeds-ht))))))
+            (cl-incf (cadr (gethash feed-id feeds-ht)))
+          (cl-incf (caddr (gethash feed-id feeds-ht))))))
     (cons (hash-table-values feeds-ht) (hash-table-values tags-ht))))
 
 (defun elfeed-tree--build-nested (nodes)

--- a/elfeed.el
+++ b/elfeed.el
@@ -573,10 +573,10 @@ URL identifies the feed and XML is the parsed content."
   (cl-typecase feed
     (list (let ((autotags (elfeed--plist-skip (cdr feed))))
             (and (stringp (car feed))
-                 (all (lambda (x)
-                        (and x (symbolp x) (not (keywordp x))))
-                      autotags)
-                 (evenp (- (length (cdr feed)) (length autotags))))))
+                 (cl-every (lambda (x)
+                             (and x (symbolp x) (not (keywordp x))))
+                           autotags)
+                 (cl-evenp (- (length (cdr feed)) (length autotags))))))
     (string t)))
 
 (defun elfeed-feed-list (&optional all)
@@ -615,13 +615,13 @@ feeds without the :no-update property."
 
 (defun elfeed-handle-http-error (url status)
   "Handle an http error during retrieval of URL with STATUS code."
-  (incf (elfeed-meta (elfeed-db-get-feed url) :failures 0))
+  (cl-incf (elfeed-meta (elfeed-db-get-feed url) :failures 0))
   (run-hook-with-args 'elfeed-http-error-hook url status)
   (elfeed-log 'error "%s: %S" url status))
 
 (defun elfeed-handle-parse-error (url error)
   "Handle parse error during parsing of URL with ERROR message."
-  (incf (elfeed-meta (elfeed-db-get-feed url) :failures 0))
+  (cl-incf (elfeed-meta (elfeed-db-get-feed url) :failures 0))
   (run-hook-with-args 'elfeed-parse-error-hook url error)
   (elfeed-log 'error "%s: %s" url error))
 
@@ -849,12 +849,12 @@ The returned function should be added to `elfeed-new-entry-hook'."
             (date (elfeed-entry-date entry))
             (case-fold-search t))
         (cl-labels ((match (r s)
-                    (pcase r
-                      (`nil t)
-                      (`(not ,r) (not (match r s)))
-                      (_ (if (stringp s)
-                             (string-match-p r s)
-                           (any (lambda (s) (string-match-p r s)) s))))))
+                      (pcase r
+                        (`nil t)
+                        (`(not ,r) (not (match r s)))
+                        (_ (if (stringp s)
+                               (string-match-p r s)
+                             (cl-some (lambda (s) (string-match-p r s)) s))))))
           (when (and
                  (match feed-title  (elfeed-feed-title  feed))
                  (match feed-url    (elfeed-feed-url    feed))

--- a/tests/elfeed-db-tests.el
+++ b/tests/elfeed-db-tests.el
@@ -363,7 +363,7 @@
      (should (= (elfeed-meta entry :errors 10) 10))
      (setf (elfeed-meta feed :status) 'down
            (elfeed-meta entry :rating) 4)
-     (incf (elfeed-meta entry :errors 0))
+     (cl-incf (elfeed-meta entry :errors 0))
      (should (equal 'down (elfeed-meta feed :status)))
      (should (equal 4 (elfeed-meta entry :rating)))
      (should (= (elfeed-meta entry :errors) 1))


### PR DESCRIPTION
I recently upgraded my local installation of elfeed and had these obsolete functions throwing errors, i.e., void functions.

Replacing them with the built-in CL version suppressed them and bring the code to a fully working state.

The tests are performed after these changes, and they all pass.

My environment, just in case: GNU Emacs 30.2 (build 1, x86_64-pc-linux-gnu, X toolkit, cairo version 1.18.4)