### PR TITLE
Trim url early

### DIFF
--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -356,6 +356,7 @@ The relative URL algorithm is described in RFC 3986 §5.2.4."
   "Return full URL for maybe-relative NEW-URL based on full OLD-URL."
   (if (null new-url)
       old-url
+    (setq new-url (string-trim new-url))
     (let ((old (url-generic-parse-url old-url))
           (new (url-generic-parse-url new-url)))
       (cond


### PR DESCRIPTION
Surrounding whitespace is never significant in a URL but defeats absolute-URL detection below, making an absolute link look relative.

Example at https://www.interfluidity.com/unify-rss/all-blogs-and-microblogs.rss


An item has a link like:
```
      <link>
        https://drafts.interfluidity.com/2026/06/16/multiple-parties-in-government-a-gadget-toward-accountability-and-action/index.html
      </link>
```

which results in elfeed capturing this link (note concatenation with a space between the two urls):

```
https://www.interfluidity.com/unify-rss/ https://drafts.interfluidity.com/2026/06/16/multiple-parties-in-government-a-gadget-toward-accountability-and-action/index.html
```