### PR TITLE
Run emacs with "-q" instead of "-Q"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .POSIX:
 EMACS   = emacs
-BATCH   = $(EMACS) -batch -Q -L . -L tests
+BATCH   = $(EMACS) -batch -q -L . -L tests
 
 EL   = elfeed-csv.el elfeed-curl.el elfeed-db.el elfeed-lib.el	\
        elfeed-log.el elfeed-show.el elfeed.el xml-query.el	\


### PR DESCRIPTION
- When running emacs with "-Q", it disables loading all external addons. This could cause the test failure when e.g. compat is not available.

- This patch switch "-Q" with "-q" to avoid loading the init file.